### PR TITLE
ci: Bump checkout v7, codecov-action v7, action-gh-release v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
@@ -29,7 +29,7 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -50,7 +50,7 @@ jobs:
     name: Security Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Install Linux dependencies
@@ -83,7 +83,7 @@ jobs:
     env:
       ORT_VERSION: "1.22.0"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Install Linux dependencies
@@ -118,7 +118,7 @@ jobs:
     env:
       ORT_VERSION: "1.22.0"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Install Linux dependencies
@@ -147,7 +147,7 @@ jobs:
           ORT_DYLIB_PATH: /home/runner/.local/lib/onnxruntime/lib/libonnxruntime.so
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           files: cobertura.xml
           fail_ci_if_error: false
@@ -187,7 +187,7 @@ jobs:
             target: x86_64-pc-windows-msvc
             artifact: openhush.exe
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -232,7 +232,7 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Install Linux dependencies
@@ -271,7 +271,7 @@ jobs:
             name: Vulkan (Linux)
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
 
       # Linux dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -150,7 +150,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Download Linux artifact
         uses: actions/download-artifact@v8
@@ -234,7 +234,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Download macOS artifacts
         uses: actions/download-artifact@v8
@@ -322,7 +322,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Download Windows artifact
         uses: actions/download-artifact@v8
@@ -378,7 +378,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Download all artifacts
         uses: actions/download-artifact@v8
@@ -403,7 +403,7 @@ jobs:
           cat openhush-${{ github.ref_name }}-checksums.txt
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             release/*.tar.gz


### PR DESCRIPTION
Completes the GitHub Actions updates started alongside the v0.8.0 dependency work. #229 covered `upload-artifact`, `download-artifact` and `codecov-action` (to v5, which was what Dependabot had proposed); these are the remaining ones, taken to current.

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | **v7** |
| `codecov/codecov-action` | v5 | **v7** |
| `softprops/action-gh-release` | v2 | **v3** |

Already current, left alone:

- `Swatinem/rust-cache@v2` — the `v2` tag tracks 2.9.2
- `actions/upload-artifact@v7`, `actions/download-artifact@v8` — latest majors
- `dtolnay/rust-toolchain@stable` — branch ref, not versioned

## Compatibility

All three majors move the action runtime to **Node.js 24** and require runner **2.327.1+**. Every job runs on GitHub-hosted runners (`ubuntu-latest`, `ubuntu-22.04`, `macos-14`, `windows-latest`, plus the build matrix), so that requirement is met. No self-hosted runners are involved.

`checkout` v7 additionally blocks checking out fork pull requests from `pull_request_target` and `workflow_run`. Neither workflow uses those triggers — CI runs on `push`/`pull_request` and release runs on tag push — so the restriction does not apply.

`codecov-action` v7 switches the signing account to `codecovsecops` after the keybase migration; the original GPG key is retained.

Both workflow files validated as YAML.