### PR TITLE
chore(release): Update packaging and platform matrix for v0.8.0

### DIFF
--- a/packaging/README.md
+++ b/packaging/README.md
@@ -58,7 +58,7 @@ cp -r packaging/deb/debian .
 dpkg-buildpackage -us -uc -b
 
 # Install
-sudo dpkg -i ../openhush_0.5.0-1_amd64.deb
+sudo dpkg -i ../openhush_0.8.0-1_amd64.deb
 ```
 
 ---
@@ -92,10 +92,10 @@ brew install create-dmg
 
 # Build DMG
 cd packaging/macos
-./build-dmg.sh 0.5.0 ../../target/release/openhush
+./build-dmg.sh 0.8.0 ../../target/release/openhush
 
 # Optional: Sign and notarize
-./sign-and-notarize.sh OpenHush.app OpenHush-0.5.0-macos-universal.dmg
+./sign-and-notarize.sh OpenHush.app OpenHush-0.8.0-macos-universal.dmg
 ```
 
 **Code Signing:**
@@ -117,10 +117,10 @@ cd packaging/macos
 
 # Build MSI
 cd packaging\windows
-.\build-msi.ps1 -Version 0.5.0 -SourceDir ..\..\target\release
+.\build-msi.ps1 -Version 0.8.0 -SourceDir ..\..\target\release
 ```
 
-**Output:** `output/OpenHush-0.5.0-x64.msi`
+**Output:** `output/OpenHush-0.8.0-x64.msi`
 
 ---
 

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,32 @@
+openhush (0.8.0-1) unstable; urgency=medium
+
+  * Lazygit-style terminal user interface (TUI)
+  * Unified IPC with event subscriptions and audio level streaming
+  * Maximum audio duration raised from 5 minutes to 2 hours
+  * Fixed microphone selection skipping PulseAudio monitor sources
+  * Fixed inverted translation flag
+
+ -- OpenHush Team <christian.kamien@gmail.com>  Sun, 16 Aug 2026 10:00:00 +0200
+
+openhush (0.7.0-1) unstable; urgency=medium
+
+  * Windows system audio capture via WASAPI loopback
+  * macOS system audio capture via ScreenCaptureKit (macOS 13+)
+  * Cross-platform recording module
+
+ -- OpenHush Team <christian.kamien@gmail.com>  Sat, 03 Jan 2026 10:00:00 +0100
+
+openhush (0.6.0-1) unstable; urgency=medium
+
+  * Wake word detection via openWakeWord ONNX models
+  * Real-time translation with M2M-100
+  * Meeting summarization with configurable LLM backends
+  * System audio capture via PulseAudio/PipeWire monitor sources
+  * REST API with Swagger UI
+  * Post-transcription actions and app-aware profiles
+
+ -- OpenHush Team <christian.kamien@gmail.com>  Wed, 31 Dec 2025 10:00:00 +0100
+
 openhush (0.5.0-1) unstable; urgency=medium
 
   * Initial Debian package release

--- a/packaging/flatpak/org.openhush.OpenHush.metainfo.xml
+++ b/packaging/flatpak/org.openhush.OpenHush.metainfo.xml
@@ -89,6 +89,39 @@
   </screenshots>
 
   <releases>
+    <release version="0.8.0" date="2026-08-16">
+      <description>
+        <p>v0.8.0 - Terminal User Interface</p>
+        <ul>
+          <li>Lazygit-style terminal user interface with live audio meter</li>
+          <li>Unified IPC with event subscriptions and audio level streaming</li>
+          <li>Maximum audio duration raised from 5 minutes to 2 hours</li>
+          <li>Microphone selection no longer falls back to monitor sources</li>
+        </ul>
+      </description>
+    </release>
+    <release version="0.7.0" date="2026-01-03">
+      <description>
+        <p>v0.7.0 - Platform Parity for System Audio Capture</p>
+        <ul>
+          <li>Windows system audio capture via WASAPI loopback</li>
+          <li>macOS system audio capture via ScreenCaptureKit (macOS 13+)</li>
+          <li>Cross-platform recording module</li>
+        </ul>
+      </description>
+    </release>
+    <release version="0.6.0" date="2025-12-31">
+      <description>
+        <p>v0.6.0 - Advanced Features and Extensibility</p>
+        <ul>
+          <li>Wake word detection via openWakeWord ONNX models</li>
+          <li>Real-time translation with M2M-100</li>
+          <li>Meeting summarization with configurable LLM backends</li>
+          <li>REST API with Swagger UI</li>
+          <li>Post-transcription actions and app-aware profiles</li>
+        </ul>
+      </description>
+    </release>
     <release version="0.5.0" date="2025-12-26">
       <description>
         <p>v0.5.0 - Linux Desktop Integration</p>

--- a/packaging/flatpak/org.openhush.OpenHush.yml
+++ b/packaging/flatpak/org.openhush.OpenHush.yml
@@ -72,7 +72,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/claymore666/openhush.git
-        tag: v0.5.0
+        tag: v0.8.0
         # commit: <will be filled on release>
 
       # Cargo dependencies (generated with flatpak-cargo-generator)

--- a/packaging/homebrew/openhush.cask.rb
+++ b/packaging/homebrew/openhush.cask.rb
@@ -2,7 +2,7 @@
 # Use this if distributing as a .app bundle
 
 cask "openhush" do
-  version "0.5.0"
+  version "0.8.0"
   sha256 "PLACEHOLDER_SHA256"  # Update with actual SHA256 on release
 
   url "https://github.com/claymore666/openhush/releases/download/v#{version}/OpenHush-#{version}-macos-universal.dmg"

--- a/packaging/homebrew/openhush.rb
+++ b/packaging/homebrew/openhush.rb
@@ -1,7 +1,7 @@
 class Openhush < Formula
   desc "Open-source voice-to-text that acts as a seamless whisper keyboard"
   homepage "https://github.com/claymore666/openhush"
-  url "https://github.com/claymore666/openhush/archive/refs/tags/v0.5.0.tar.gz"
+  url "https://github.com/claymore666/openhush/archive/refs/tags/v0.8.0.tar.gz"
   sha256 "PLACEHOLDER_SHA256"  # Update with actual SHA256 on release
   license "MIT"
   head "https://github.com/claymore666/openhush.git", branch: "main"

--- a/packaging/macos/build-dmg.sh
+++ b/packaging/macos/build-dmg.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-VERSION="${1:-0.5.0}"
+VERSION="${1:-0.8.0}"
 BINARY_PATH="${2:-../../target/release/openhush}"
 OUTPUT_DIR="${3:-.}"
 APP_NAME="OpenHush"

--- a/packaging/windows/build-msi.ps1
+++ b/packaging/windows/build-msi.ps1
@@ -2,7 +2,7 @@
 # Requires: WiX Toolset v4+ (https://wixtoolset.org/)
 
 param(
-    [string]$Version = "0.5.0",
+    [string]$Version = "0.8.0",
     [string]$SourceDir = "..\..\target\release",
     [string]$OutputDir = ".\output"
 )

--- a/packaging/windows/openhush.wxs
+++ b/packaging/windows/openhush.wxs
@@ -7,7 +7,7 @@
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
   <Package Name="OpenHush"
            Manufacturer="OpenHush Team"
-           Version="0.5.0"
+           Version="0.8.0"
            UpgradeCode="E8F3A2B1-5C4D-4E6F-8A9B-0C1D2E3F4A5B"
            Scope="perUser">
 

--- a/wiki/Platform-Support.md
+++ b/wiki/Platform-Support.md
@@ -62,6 +62,12 @@ This document tracks feature availability across all supported platforms.
 | D-Bus control | ✅ | N/A | N/A | - |
 | IPC control (pipes/socket) | N/A | ✅ | ✅ | Closed |
 | Autostart (service install) | ✅ | ✅ | ✅ | Closed |
+| IPC event subscriptions | ✅ | ✅ | ❌ | #198 |
+| Audio level streaming (20Hz) | ✅ | ✅ | ❌ | #198 |
+
+The event-broadcasting server (`IpcServer`) is backed by a Unix socket. On
+Windows the daemon side compiles to no-op stubs, so subscriptions and audio
+level streaming are unavailable there.
 
 ---
 
@@ -71,6 +77,23 @@ This document tracks feature availability across all supported platforms.
 |---------|-------|-------|---------|-------|
 | Preferences dialog | ✅ | ✅ | ✅ | Closed |
 | Onboarding wizard | ✅ | ✅ | ✅ | Closed |
+
+---
+
+## Terminal UI (TUI)
+
+| Feature | Linux | macOS | Windows | Issue |
+|---------|-------|-------|---------|-------|
+| Dashboard layout | ✅ | ✅ | ✅ | #171 |
+| Keyboard navigation and help overlay | ✅ | ✅ | ✅ | #171 |
+| Colour themes (terminal/dark/light) | ✅ | ✅ | ✅ | #171 |
+| Panic handler (terminal restore) | ✅ | ✅ | ✅ | #171 |
+| Live daemon connection | ✅ | ✅ | ❌ | #198 |
+| Real-time audio level meter | ✅ | ✅ | ❌ | #198 |
+
+The TUI itself renders on every platform. The panels that show live state
+depend on the daemon-side IPC server, so on Windows the interface starts but
+stays disconnected until that server gains a named-pipe backend.
 
 ---
 


### PR DESCRIPTION
Release-checklist work for v0.8.0: packaging version bumps and the platform support matrix.

## Packaging was three releases behind

Every packaging file except `Cargo.toml` and the AUR `PKGBUILD` still read **0.5.0** — they were not updated for 0.6.0 or 0.7.0 either. The deb changelog and the AppStream metainfo are cumulative, so they get backfilled 0.6.0 and 0.7.0 entries alongside 0.8.0 rather than jumping from 0.5.0 to 0.8.0.

| File | Before | After |
|---|---|---|
| `deb/debian/changelog` | 0.5.0 | 0.8.0 (+ 0.7.0, 0.6.0 backfilled) |
| `flatpak/*.metainfo.xml` | 0.5.0 | 0.8.0 (+ 0.7.0, 0.6.0 backfilled) |
| `flatpak/*.yml` (git tag) | v0.5.0 | v0.8.0 |
| `homebrew/openhush.rb` (url) | v0.5.0 | v0.8.0 |
| `windows/openhush.wxs` | 0.5.0 | 0.8.0 |
| `aur/PKGBUILD` | already 0.8.0 | unchanged |

### Not on the checklist, but stale

Three files carry a version the checklist does not mention, and each would have produced mislabelled artifacts:

- `homebrew/openhush.cask.rb` — `version "0.5.0"`, which also feeds the DMG download URL
- `macos/build-dmg.sh` — `VERSION="${1:-0.5.0}"` default
- `windows/build-msi.ps1` — `$Version = "0.5.0"` default

Worth adding these to the checklist in `packaging/README.md` so the next release does not miss them again.

## Platform matrix

New sections for the TUI (#171) and IPC event subscriptions (#198). Both record that the daemon-side `IpcServer` is Unix-socket backed and compiles to no-op stubs on Windows (`src/ipc/server.rs`), so the TUI starts there but stays disconnected — the audio meter and live status need a named-pipe backend before Windows is at parity.

## Still outstanding

`homebrew/openhush.rb` and `openhush.cask.rb` keep `PLACEHOLDER_SHA256`, and `PKGBUILD` keeps `sha256sums=('SKIP')`. Those checksums cover the release tarball and can only be computed once the `v0.8.0` tag exists, so they are a follow-up.

All XML and YAML files validated after editing.