### PR TITLE
fix(ci): Repair release Linux build and create releases as drafts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libasound2-dev libxdo-dev libdbus-1-dev \
             libxtst-dev libx11-dev libxi-dev libxrandr-dev libxcursor-dev libxinerama-dev \
-            libglib2.0-dev libgtk-3-dev libpulse-dev libpulse-dev
+            libglib2.0-dev libgtk-3-dev libpulse-dev
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy -- -D warnings
 
@@ -58,7 +58,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libasound2-dev libxdo-dev libdbus-1-dev \
             libxtst-dev libx11-dev libxi-dev libxrandr-dev libxcursor-dev libxinerama-dev \
-            libglib2.0-dev libgtk-3-dev libpulse-dev libpulse-dev
+            libglib2.0-dev libgtk-3-dev libpulse-dev
 
       - name: Install cargo-audit
         run: cargo install cargo-audit
@@ -91,7 +91,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libasound2-dev libxdo-dev libdbus-1-dev \
             libxtst-dev libx11-dev libxi-dev libxrandr-dev libxcursor-dev libxinerama-dev \
-            libglib2.0-dev libgtk-3-dev libpulse-dev libpulse-dev
+            libglib2.0-dev libgtk-3-dev libpulse-dev
 
       - name: Download ONNX Runtime
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -420,7 +420,9 @@ jobs:
             release/*.msi
             release/*-checksums.txt
           generate_release_notes: true
-          draft: false
+          # Created unpublished so the artifacts can be checked before they
+          # reach anyone. Publish from the Releases page once they look right.
+          draft: true
           prerelease: ${{ contains(github.ref_name, '-') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,14 @@ jobs:
             libxi-dev \
             libxtst-dev \
             libxcb1-dev \
-            libxkbcommon-dev
+            libxkbcommon-dev \
+            libxdo-dev \
+            libxrandr-dev \
+            libxcursor-dev \
+            libxinerama-dev \
+            libglib2.0-dev \
+            libgtk-3-dev \
+            libpulse-dev
 
       # macOS dependencies
       - name: Install macOS dependencies


### PR DESCRIPTION
Two changes to `release.yml`, both needed before v0.8.0 can be re-tagged.

## 1. The Linux release build was broken

The v0.8.0 release produced no artifacts. macOS (both arches) and Windows built fine; Linux failed at link time:

```
rust-lld: error: unable to find library -l:libpulse.so.0
collect2: error: ld returned 1 exit status
```

`release.yml`'s Linux dependency list was never updated when `libpulse-binding` was added in 0.6.0 for system audio capture. Comparing against `ci.yml`, seven packages were missing:

`libpulse-dev`, `libxdo-dev`, `libxrandr-dev`, `libxcursor-dev`, `libxinerama-dev`, `libglib2.0-dev`, `libgtk-3-dev`

Only `libpulse-dev` broke the link, but the rest are equally absent and `libxdo-dev` backs `enigo`, so the whole set is brought in line with `ci.yml`.

**Why CI never caught it:** `release.yml` only runs on `v*.*.*` tag pushes, so its dependency list is exercised about once per release and drifted unnoticed. The v0.7.0 release run also failed, almost certainly for the same reason — no release since v0.6.0 has published artifacts.

Also removes a duplicated `libpulse-dev` that appeared twice on one line in three `ci.yml` jobs.

## 2. Releases are now drafts

`draft: false` meant a successful run published immediately and publicly, with artifacts attached and watchers notified. The job already refuses to run unless every build and packaging job passes (`needs: [build, package-linux, package-macos, package-windows]`), which covers outright failure — but not the successful-but-wrong case: a `.deb` that installs nothing, an `.msi` with a bad version, a binary that will not start.

With `draft: true` the artifacts are still built and attached automatically; publishing becomes one click on the Releases page, and the generated notes can be edited first. Given this workflow has not produced a usable artifact in two releases, that seems worth the click.

## Verification

Neither change can be fully verified by this PR's CI, since the file it edits only runs on tag push. The proof is re-tagging v0.8.0 after merge. Both workflows validated as YAML.
