### PR TITLE
ci(release): Pin WiX Toolset to v6.0.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -345,7 +345,10 @@ jobs:
       - name: Install WiX Toolset
         shell: pwsh
         run: |
-          dotnet tool install --global wix
+          # Pinned: WiX v7 refuses to build until the Open Source Maintenance
+          # Fee EULA is accepted (WIX7015). v6 is the last version without that
+          # gate. Unpinning is what silently moved us onto v7 mid-release.
+          dotnet tool install --global wix --version 6.0.2
 
       - name: Build MSI
         shell: pwsh


### PR DESCRIPTION
## Problem

The v0.8.0 release build failed in `package-windows`:

```
error WIX7015: You must accept the Open Source Maintenance Fee (OSMF) EULA to use WiX Toolset v7
```

`dotnet tool install --global wix` had no version constraint. WiX v7.0.0 shipped 2026-04-06, after v0.7.0 was tagged, so the workflow silently jumped a major version. v7 is the first release to *enforce* the Open Source Maintenance Fee EULA; v6 introduced the fee but never gated on it.

Same failure mode as the unpinned `ort` pre-release: build tooling that resolves to "latest" breaks on a schedule nobody controls.

## Fix

Pin to `6.0.2`, the last version without the acceptance gate — which is what this job was effectively building with until v7 shipped.

## Note on moving to v7 later

v7 can be used by passing `-acceptEula wix7` to `wix build`. Under OSMF v1.1 the fee only applies above US$10,000 annual revenue, so this project is exempt — but accepting a EULA in the repo is a maintainer decision, not one to make implicitly in a hotfix. Left for a follow-up.