### PR TITLE
fix(packaging): Repair WiX authoring for v4+ schema

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -349,6 +349,8 @@ jobs:
           # Fee EULA is accepted (WIX7015). v6 is the last version without that
           # gate. Unpinning is what silently moved us onto v7 mid-release.
           dotnet tool install --global wix --version 6.0.2
+          # WixUI_Minimal lives in the UI extension, which is not built in.
+          wix extension add -g WixToolset.UI.wixext/6.0.2
 
       - name: Build MSI
         shell: pwsh
@@ -366,6 +368,7 @@ jobs:
           # Build MSI
           cd packaging\windows
           wix build openhush.wxs `
+              -ext WixToolset.UI.wixext `
               -d SourceDir="." `
               -d Version="$version" `
               -o "..\..\openhush-${{ github.ref_name }}-x64.msi"

--- a/packaging/windows/openhush.wxs
+++ b/packaging/windows/openhush.wxs
@@ -4,7 +4,8 @@
   Build with: wix build openhush.wxs -o openhush.msi
   Or use cargo-wix: cargo wix
 -->
-<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs"
+     xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
   <Package Name="OpenHush"
            Manufacturer="OpenHush Team"
            Version="0.8.0"
@@ -41,7 +42,6 @@
                     Directory="ApplicationProgramsFolder"
                     Description="Open-source voice-to-text"
                     WorkingDirectory="BinFolder"
-                    Icon="openhush.ico"
                     Advertise="yes" />
         </File>
 
@@ -56,8 +56,10 @@
       </Component>
     </ComponentGroup>
 
-    <!-- Icon for shortcuts -->
-    <Icon Id="openhush.ico" SourceFile="$(var.SourceDir)\openhush.ico" />
+    <!-- No Icon element: the repository ships no openhush.ico, and an
+         advertised shortcut without one falls back to the icon embedded in
+         its KeyPath file (openhush.exe). Add one back here if a real .ico
+         is ever committed. -->
 
     <!-- Features -->
     <Feature Id="ProductFeature" Title="OpenHush" Level="1">
@@ -70,15 +72,16 @@
                   ExeCommand="preferences"
                   Return="asyncNoWait" />
 
-    <!-- UI -->
+    <!-- UI. The dialog set is referenced through ui:WixUI rather than UIRef:
+         the WixUI symbols are internal to the extension in WiX v4+, so UIRef
+         fails to link with "inaccessible due to its protection level". -->
+    <ui:WixUI Id="WixUI_Minimal" />
     <UI>
-      <UIRef Id="WixUI_Minimal" />
       <Publish Dialog="ExitDialog"
                Control="Finish"
                Event="DoAction"
-               Value="LaunchApplication">
-        WIXUI_EXITDIALOGOPTIONALCHECKBOX = 1 and NOT Installed
-      </Publish>
+               Value="LaunchApplication"
+               Condition="WIXUI_EXITDIALOGOPTIONALCHECKBOX = 1 and NOT Installed" />
     </UI>
 
     <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT" Value="Launch OpenHush" />


### PR DESCRIPTION
Follow-up to #233. With the EULA gate gone, WiX 6.0.2 could finally *compile* `openhush.wxs` — and it turns out the file has never once been built successfully.

Checking the release history confirms it: v0.4.0 shipped only raw binaries, and v0.5.0/v0.6.0 have no assets at all. **No OpenHush release has ever contained an .msi, .deb, or .dmg.** The packaging jobs were written but never validated.

## Three errors, all verified locally against WiX 6.0.2

1. **`WIX0400`** — `Publish` carried its condition as inner text (v3 style). In v4+ that moved to a `Condition` attribute.
2. **`WIX0094`** — `WixUI_Minimal` was referenced with `UIRef`, which fails to link: the WixUI symbols are internal to the extension in v4+ (*"inaccessible due to its protection level"*). Needs the `ui:WixUI` element plus `WixToolset.UI.wixext`, which the workflow never installed or passed.
3. **Missing asset** — the `Icon` element pointed at `openhush.ico`, which is not in the repo and is not produced by the build. `build-msi.ps1` only warns about this. Dropped the element; an advertised shortcut falls back to the icon embedded in its KeyPath file.

Only the first was visible from CI — the compiler stops at the first phase, so 2 and 3 would each have cost another tag-and-wait cycle.

## Verification

Validated by installing .NET + WiX 6.0.2 locally and compiling the real file. WiX on Linux reports `WIX0389`/`WIX0027` for any `Directory/@Name` and any backslash path — a platform limitation (it prints *"only supports Windows... behavior undefined"*), reproducible with a one-line `Name="abc"` test case. Those do not occur on Windows: the CI run reported *only* `WIX0400`. So compile-phase validation is trustworthy here; the link/bind phase still gets its first real exercise on the next tag.

No Rust changed. `cargo fmt --check` and `cargo clippy -- -D warnings` pass.