### PR TITLE
fix(packaging): Fill in v0.8.0 checksums and correct cask URL

### DIFF
--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -27,7 +27,7 @@ optdepends=(
 provides=('openhush')
 conflicts=('openhush-git')
 source=("$pkgname-$pkgver.tar.gz::https://github.com/claymore666/openhush/archive/v$pkgver.tar.gz")
-sha256sums=('SKIP')
+sha256sums=('5a210a9cfdd63c7a4fa8300b377996886a91fdffe93dc3108b6b2813194f9c20')
 
 prepare() {
     cd "$pkgname-$pkgver"

--- a/packaging/homebrew/openhush.cask.rb
+++ b/packaging/homebrew/openhush.cask.rb
@@ -3,9 +3,11 @@
 
 cask "openhush" do
   version "0.8.0"
-  sha256 "PLACEHOLDER_SHA256"  # Update with actual SHA256 on release
+  sha256 "52882913ac51b26d1414db247022ad73b228c9bc32a070a5e6e08c11f7f5db25"
 
-  url "https://github.com/claymore666/openhush/releases/download/v#{version}/OpenHush-#{version}-macos-universal.dmg"
+  # Filename must match what release.yml actually uploads:
+  # openhush-v<version>-macos-universal.dmg
+  url "https://github.com/claymore666/openhush/releases/download/v#{version}/openhush-v#{version}-macos-universal.dmg"
   name "OpenHush"
   desc "Open-source voice-to-text that acts as a seamless whisper keyboard"
   homepage "https://github.com/claymore666/openhush"

--- a/packaging/homebrew/openhush.rb
+++ b/packaging/homebrew/openhush.rb
@@ -2,7 +2,7 @@ class Openhush < Formula
   desc "Open-source voice-to-text that acts as a seamless whisper keyboard"
   homepage "https://github.com/claymore666/openhush"
   url "https://github.com/claymore666/openhush/archive/refs/tags/v0.8.0.tar.gz"
-  sha256 "PLACEHOLDER_SHA256"  # Update with actual SHA256 on release
+  sha256 "5a210a9cfdd63c7a4fa8300b377996886a91fdffe93dc3108b6b2813194f9c20"
   license "MIT"
   head "https://github.com/claymore666/openhush.git", branch: "main"
 


### PR DESCRIPTION
Completes the v0.8.0 release checklist now that the tag and artifacts exist.

## Checksums

All three package definitions shipped without working integrity checks:

| File | Was | Now |
|---|---|---|
| `homebrew/openhush.rb` | `PLACEHOLDER_SHA256` | source archive digest |
| `homebrew/openhush.cask.rb` | `PLACEHOLDER_SHA256` | .dmg digest |
| `aur/PKGBUILD` | `sha256sums=('SKIP')` | source archive digest |

Source archive: `5a210a9c…` — verified identical for both the `/archive/refs/tags/v0.8.0.tar.gz` and `/archive/v0.8.0.tar.gz` URL forms, since the formula and PKGBUILD use different ones.

DMG: `52882913…`, computed from the artifact the release workflow actually produced.

## Cask URL was broken

```
expected: OpenHush-0.8.0-macos-universal.dmg
actual:   openhush-v0.8.0-macos-universal.dmg
```

Wrong case and a missing `v` prefix — `brew install --cask openhush` would have 404'd regardless of the checksum. This was invisible until now because no release had ever produced a .dmg to compare against.

Packaging metadata only; no Rust changed.