### PR TITLE
fix(packaging): Declare missing .deb runtime deps; move WiX to v7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,7 +199,7 @@ jobs:
           Section: utils
           Priority: optional
           Architecture: amd64
-          Depends: libasound2, libdbus-1-3
+          Depends: libasound2, libdbus-1-3, libpulse0, libx11-6, libxtst6
           Maintainer: OpenHush Team <christian.kamien@gmail.com>
           Description: Voice-to-text transcription tool
            OpenHush is a local, privacy-focused voice-to-text tool
@@ -345,12 +345,15 @@ jobs:
       - name: Install WiX Toolset
         shell: pwsh
         run: |
-          # Pinned: WiX v7 refuses to build until the Open Source Maintenance
-          # Fee EULA is accepted (WIX7015). v6 is the last version without that
-          # gate. Unpinning is what silently moved us onto v7 mid-release.
-          dotnet tool install --global wix --version 6.0.2
+          # Pinned deliberately: an unpinned install is what silently moved
+          # this job onto a new major version mid-release.
+          dotnet tool install --global wix --version 7.0.0
+          # v7 refuses to run until the Open Source Maintenance Fee EULA is
+          # accepted (WIX7015). Accepted for this project by the maintainer;
+          # the fee itself applies only above US$10,000 annual revenue.
+          wix eula accept wix7
           # WixUI_Minimal lives in the UI extension, which is not built in.
-          wix extension add -g WixToolset.UI.wixext/6.0.2
+          wix extension add -g WixToolset.UI.wixext/7.0.0
 
       - name: Build MSI
         shell: pwsh


### PR DESCRIPTION
## The .deb in the v0.8.0 draft is broken

Spot-checked the artifact in a clean container. It installs fine, then the binary refuses to start:

```
libpulse.so.0 => not found
libX11.so.6   => not found
libXtst.so.6  => not found

/usr/bin/openhush: error while loading shared libraries: libpulse.so.0
```

The control file declared only `libasound2, libdbus-1-3`.

### Root cause

The workflow **hand-rolls** `DEBIAN/control` inline instead of using `packaging/deb/debian/control`, which correctly relies on `${shlibs:Depends}` (and also lists `libgtk-3-0`). The two have silently drifted. `${shlibs:Depends}` would have computed this set automatically — the hand-rolled list had to be maintained by hand, and wasn't.

This PR fixes the immediate breakage by declaring the three missing packages. Consolidating onto the `debhelper` path is the better long-term fix but is a larger change.

### Verification

Rebuilt the package with the corrected `Depends` and installed it in clean containers:

| Image | install | missing libs | `openhush --version` |
|---|---|---|---|
| `ubuntu:22.04` (build target) | rc=0 | none | `openhush 0.8.0` |
| `debian:13` (trixie) | rc=0 | none | `openhush 0.8.0` |

`--help` also renders correctly on both.

## WiX 6.0.2 → 7.0.0

Per maintainer decision, accepting the OSMF EULA via `wix eula accept wix7`. The fee applies only above US$10,000 annual revenue, so no payment is owed; this is the acceptance step only. Kept pinned — unpinning is what caused the original breakage.

Confirmed `openhush.wxs` compiles under v7 locally with no new errors.

## Consequence for the release

**The current draft must not be published** — its .deb is the broken one. This needs a rebuild, so v0.8.0 has to be re-tagged, which changes the source archive and invalidates the checksums from #235. I'll recompute all three after the rebuild.

No Rust changed; `cargo fmt --check` passes.