### PR TITLE
fix(packaging): Update checksums for rebuilt v0.8.0 artifacts

### DIFF
--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -27,7 +27,7 @@ optdepends=(
 provides=('openhush')
 conflicts=('openhush-git')
 source=("$pkgname-$pkgver.tar.gz::https://github.com/claymore666/openhush/archive/v$pkgver.tar.gz")
-sha256sums=('5a210a9cfdd63c7a4fa8300b377996886a91fdffe93dc3108b6b2813194f9c20')
+sha256sums=('01c06b57c269593efda2cba6240c4256c225b82b9cf580eb39508478f7089f13')
 
 prepare() {
     cd "$pkgname-$pkgver"

--- a/packaging/homebrew/openhush.cask.rb
+++ b/packaging/homebrew/openhush.cask.rb
@@ -3,7 +3,7 @@
 
 cask "openhush" do
   version "0.8.0"
-  sha256 "52882913ac51b26d1414db247022ad73b228c9bc32a070a5e6e08c11f7f5db25"
+  sha256 "471096be71bf36913a79026e5a5befd357127417f5e109b981e54511f6906308"
 
   # Filename must match what release.yml actually uploads:
   # openhush-v<version>-macos-universal.dmg

--- a/packaging/homebrew/openhush.rb
+++ b/packaging/homebrew/openhush.rb
@@ -2,7 +2,7 @@ class Openhush < Formula
   desc "Open-source voice-to-text that acts as a seamless whisper keyboard"
   homepage "https://github.com/claymore666/openhush"
   url "https://github.com/claymore666/openhush/archive/refs/tags/v0.8.0.tar.gz"
-  sha256 "5a210a9cfdd63c7a4fa8300b377996886a91fdffe93dc3108b6b2813194f9c20"
+  sha256 "01c06b57c269593efda2cba6240c4256c225b82b9cf580eb39508478f7089f13"
   license "MIT"
   head "https://github.com/claymore666/openhush.git", branch: "main"
 


### PR DESCRIPTION
Re-tagging v0.8.0 to pick up the `.deb` dependency fix (#236) changed both the source archive and the `.dmg`, so the digests landed in #235 no longer match.

| File | New digest | Source |
|---|---|---|
| `homebrew/openhush.rb` | `01c06b57…` | source archive |
| `aur/PKGBUILD` | `01c06b57…` | source archive |
| `homebrew/openhush.cask.rb` | `471096be…` | rebuilt .dmg |

Source archive digest verified identical across both URL forms, since the formula and PKGBUILD reference different ones.

## Rebuilt .deb verified

Downloaded the actual release artifact and installed it in clean containers:

| Image | install | missing libs | `--version` | `config --show` |
|---|---|---|---|---|
| `ubuntu:22.04` | rc=0 | none | `openhush 0.8.0` | rc=0 |
| `debian:13` | rc=0 | none | `openhush 0.8.0` | rc=0 |

Shipped `Depends: libasound2, libdbus-1-3, libpulse0, libx11-6, libxtst6`.

Packaging metadata only; no Rust changed.