### PR TITLE
test(packaging): Add .deb install verification and gate the release on it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -232,6 +232,32 @@ jobs:
           path: openhush-*.deb
           if-no-files-found: error
 
+  # ==========================
+  # Verify Linux Package (.deb)
+  # ==========================
+  # A green package-linux job only proves a file was produced. v0.8.0
+  # shipped a .deb that installed cleanly and then refused to start
+  # because its Depends were incomplete. This gate installs the package
+  # in clean containers and runs the binary before anything is released.
+  verify-linux-package:
+    needs: package-linux
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Download .deb artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: openhush-deb
+          path: artifact
+
+      - name: Install and run the package in clean containers
+        run: |
+          chmod +x packaging/verify-deb.sh
+          packaging/verify-deb.sh artifact/openhush-*.deb
+
   # ===================
   # macOS Package (.dmg)
   # ===================
@@ -387,7 +413,7 @@ jobs:
   # Create GitHub Release
   # ===================
   release:
-    needs: [build, package-linux, package-macos, package-windows]
+    needs: [build, package-linux, verify-linux-package, package-macos, package-windows]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -143,6 +143,41 @@ assets/icons/
 
 ---
 
+## Verifying Packages
+
+A green packaging job only proves a file was produced, not that it works.
+The v0.8.0 `.deb` installed cleanly and then refused to start, because its
+`Depends` omitted `libpulse0`, `libx11-6` and `libxtst6`. Always verify the
+artifact, never the checkmark.
+
+### Debian/Ubuntu (.deb) — automated
+
+```bash
+# Defaults to ubuntu:22.04 (the build target) and debian:13
+packaging/verify-deb.sh path/to/openhush-v0.8.0-amd64.deb
+
+# Or against specific images
+packaging/verify-deb.sh openhush.deb ubuntu:24.04 debian:12
+```
+
+Requires `docker`. For each image it installs the package **via apt**, so
+declared dependencies must actually resolve — `dpkg -i` would leave them
+unsatisfied and hide exactly this class of bug. It then checks `ldd` reports
+no missing libraries and that `--version`, `--help` and `config --show` all
+work. Exits non-zero on the first failure.
+
+This runs automatically in `release.yml` as the `verify-linux-package` job,
+which gates the `release` job: if the package does not install and run, no
+release is created.
+
+### macOS (.dmg) and Windows (.msi) — manual
+
+Not yet automated; both need a real OS. A macOS VM is documented in
+`wiki/Platform-Support.md` (OSX-KVM). At minimum, confirm the image mounts,
+the binary launches, and it reports the expected version.
+
+---
+
 ## Release Checklist
 
 Before releasing a new version:
@@ -154,21 +189,30 @@ Before releasing a new version:
    - `packaging/flatpak/org.openhush.OpenHush.yml`
    - `packaging/flatpak/org.openhush.OpenHush.metainfo.xml`
    - `packaging/homebrew/openhush.rb`
+   - `packaging/homebrew/openhush.cask.rb`
    - `packaging/windows/openhush.wxs`
+   - `packaging/windows/build-msi.ps1`
+   - `packaging/macos/build-dmg.sh`
 
 2. **Update Checksums:**
-   - SHA256 in PKGBUILD
-   - SHA256 in Homebrew formula
 
-3. **Test Builds:**
-   - Flatpak on Ubuntu
-   - AUR on Arch
-   - Deb on Debian/Ubuntu
-   - DMG on macOS
-   - MSI on Windows
+   Only possible once the tag exists, since the digests cover the published
+   source archive and artifacts. Re-tagging invalidates them — recompute if
+   the tag moves.
+   - SHA256 in PKGBUILD (source archive)
+   - SHA256 in Homebrew formula (source archive)
+   - SHA256 in Homebrew cask (the built `.dmg`)
+
+3. **Verify Packages:**
+   - `.deb` — automatic via `verify-linux-package`; run `packaging/verify-deb.sh`
+     locally to reproduce
+   - `.dmg` on macOS — manual
+   - `.msi` on Windows — manual
+   - Flatpak on Ubuntu, AUR on Arch
 
 4. **Upload Artifacts:**
-   - Attach .deb, .dmg, .msi to GitHub Release
+   - `release.yml` attaches .deb, .dmg, .msi automatically and creates the
+     release as a **draft** — inspect, then publish by hand
    - Update Flathub PR
    - Update AUR package
 

--- a/packaging/verify-deb.sh
+++ b/packaging/verify-deb.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+#
+# Verify that a built .deb actually installs and runs.
+#
+# A green packaging job only proves a file was produced. The v0.8.0 .deb
+# installed cleanly and then failed to start, because the control file
+# declared libasound2 and libdbus-1-3 but the binary also needs libpulse,
+# libX11 and libXtst. This script exists so that can never ship silently
+# again: it installs the package in clean containers and runs the binary.
+#
+# Usage:
+#   packaging/verify-deb.sh <path-to-deb> [image ...]
+#
+# Defaults to the build target plus current Debian stable. Any extra
+# arguments replace the default image list.
+#
+# Requires docker. Exits non-zero on the first image that fails.
+
+set -euo pipefail
+
+DEB_PATH="${1:-}"
+if [[ -z "${DEB_PATH}" || ! -f "${DEB_PATH}" ]]; then
+    echo "usage: $0 <path-to-deb> [image ...]" >&2
+    exit 2
+fi
+shift || true
+
+if [[ $# -gt 0 ]]; then
+    IMAGES=("$@")
+else
+    # ubuntu:22.04 is what release.yml builds on; debian:13 catches the
+    # t64 library renames that a newer stable can introduce.
+    IMAGES=("ubuntu:22.04" "debian:13")
+fi
+
+DEB_ABS="$(cd "$(dirname "${DEB_PATH}")" && pwd)/$(basename "${DEB_PATH}")"
+DEB_NAME="$(basename "${DEB_ABS}")"
+
+# Version the binary must report, taken from the package metadata so the
+# script has an independent expectation rather than trusting whatever runs.
+EXPECTED_VERSION="$(dpkg-deb -f "${DEB_ABS}" Version 2>/dev/null || true)"
+if [[ -z "${EXPECTED_VERSION}" ]]; then
+    echo "FAIL: could not read Version from ${DEB_NAME}" >&2
+    exit 1
+fi
+
+echo "Package:  ${DEB_NAME}"
+echo "Version:  ${EXPECTED_VERSION}"
+echo "Depends:  $(dpkg-deb -f "${DEB_ABS}" Depends)"
+echo "Images:   ${IMAGES[*]}"
+echo
+
+# Runs inside the container. Kept as a single here-doc so the script has
+# no runtime dependency on files other than the .deb itself.
+read -r -d '' PROBE <<'PROBE_EOF' || true
+set -u
+fail() { echo "FAIL: $*"; exit 1; }
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -qq >/dev/null 2>&1 || fail "apt-get update"
+
+# Install through apt so declared dependencies are actually resolved.
+# dpkg -i would happily leave them unsatisfied and hide the bug.
+apt-get install -y -qq "/work/${DEB_NAME}" >/dev/null 2>&1 \
+    || fail "apt-get install refused the package (unsatisfiable Depends?)"
+echo "  ok  install"
+
+MISSING="$(ldd /usr/bin/openhush 2>/dev/null | grep -i 'not found' || true)"
+[ -n "${MISSING}" ] && fail "unresolved shared libraries:
+${MISSING}"
+echo "  ok  no missing shared libraries"
+
+ACTUAL="$(/usr/bin/openhush --version 2>&1 | head -1 || true)"
+case "${ACTUAL}" in
+    *"${EXPECTED_VERSION}"*) echo "  ok  --version reports '${ACTUAL}'" ;;
+    *) fail "--version printed '${ACTUAL}', expected it to contain '${EXPECTED_VERSION}'" ;;
+esac
+
+/usr/bin/openhush --help >/dev/null 2>&1 || fail "--help exited non-zero"
+echo "  ok  --help"
+
+# Exercises config loading and the XDG path logic, which is the first
+# thing to break in a bare environment with no HOME contents.
+/usr/bin/openhush config --show >/dev/null 2>&1 || fail "config --show exited non-zero"
+echo "  ok  config --show"
+PROBE_EOF
+
+STATUS=0
+for image in "${IMAGES[@]}"; do
+    echo "=== ${image} ==="
+    if docker run --rm \
+        -v "${DEB_ABS}:/work/${DEB_NAME}:ro" \
+        -e "DEB_NAME=${DEB_NAME}" \
+        -e "EXPECTED_VERSION=${EXPECTED_VERSION}" \
+        "${image}" bash -c "${PROBE}"
+    then
+        echo "PASS ${image}"
+    else
+        echo "FAIL ${image}"
+        STATUS=1
+    fi
+    echo
+done
+
+if [[ ${STATUS} -eq 0 ]]; then
+    echo "All images passed."
+else
+    echo "One or more images failed." >&2
+fi
+exit ${STATUS}


### PR DESCRIPTION
Makes the ad-hoc container checks from the v0.8.0 release a permanent part of the pipeline.

## Why

The v0.8.0 `.deb` passed CI, produced a file, and was completely non-functional — it installed cleanly and then refused to start because its `Depends` omitted `libpulse0`, `libx11-6` and `libxtst6`. Nothing in the pipeline ever ran the packaged binary, so the green checkmark carried no information about whether the package worked.

## What

`packaging/verify-deb.sh` installs the package in clean containers and exercises it:

| Check | Why |
|---|---|
| install **via apt** | `dpkg -i` leaves dependencies unsatisfied and hides exactly this bug |
| `ldd` has no "not found" | catches the under-declared `Depends` directly |
| `--version` matches package metadata | independent expectation, not whatever the binary says |
| `--help` | basic CLI wiring |
| `config --show` | config loading and XDG paths in a bare environment |

Defaults to `ubuntu:22.04` (the build target) and `debian:13` — the latter catches `t64` library renames in newer stables. Extra args override the image list.

Wired in as `verify-linux-package`, which `release` now depends on. **A package that doesn't install and run blocks the release outright.**

## Verified in both directions

A test that can't fail is worthless, so I checked it detects the original bug:

```
GOOD package    → PASS ubuntu:22.04, PASS debian:13
REGRESSION deb  → FAIL both, exit 1:
                    libpulse.so.0 => not found
                    libX11.so.6 => not found
                    libXtst.so.6 => not found
```

The regression package is the shipped v0.8.0 `.deb` rebuilt with the old `Depends` line.

## Also

- Documents the procedure in `packaging/README.md`, including that `.dmg`/`.msi` remain manual
- Fills three gaps in the release checklist — `openhush.cask.rb`, `build-msi.ps1` and `build-dmg.sh` were all version-bumped by hand this release but never listed
- Notes that checksums can only be computed after tagging, and that re-tagging invalidates them

Placed in `packaging/` rather than `scripts/`, since `.gitignore` excludes `scripts/` as "Local test scripts".

`shellcheck` clean. No Rust changed.