### PR TITLE
fix(packaging): Derive .deb dependencies from the binary; wire MSI version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,7 +174,17 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y debhelper fakeroot
+          sudo apt-get install -y debhelper fakeroot dpkg-dev
+          # dpkg-shlibdeps resolves each NEEDED library to the package that
+          # ships it, which requires those packages to be installed here.
+          # Without them it cannot see the dependency at all.
+          sudo apt-get install -y \
+            libasound2 \
+            libdbus-1-3 \
+            libpulse0 \
+            libx11-6 \
+            libxtst6 \
+            libssl3
 
       - name: Build .deb package
         run: |
@@ -192,6 +202,38 @@ jobs:
           cp artifact/openhush "${PKG_DIR}/usr/bin/"
           chmod 755 "${PKG_DIR}/usr/bin/openhush"
 
+          # Derive the runtime dependencies from the binary itself.
+          #
+          # This list used to be written by hand and drifted out of sync with
+          # what the binary actually links against: v0.8.0 shipped a package
+          # that installed cleanly and then could not start, because libpulse,
+          # libX11 and libXtst were missing from it. dpkg-shlibdeps reads the
+          # ELF NEEDED entries and maps each one to the package that provides
+          # it, so the list cannot drift again.
+          #
+          # Deliberately no --ignore-missing-info: that flag drops libraries
+          # it cannot resolve instead of failing, which is exactly how an
+          # incomplete list would slip through unnoticed.
+          mkdir -p shlibdeps/debian
+          cat > shlibdeps/debian/control << 'CTRL'
+          Source: openhush
+
+          Package: openhush
+          Architecture: amd64
+          Depends: ${shlibs:Depends}
+          Description: placeholder used only to compute dependencies
+           dpkg-shlibdeps requires a debian/control to run against.
+          CTRL
+
+          SHLIB_DEPS="$(cd shlibdeps && dpkg-shlibdeps -O \
+              "../${PKG_DIR}/usr/bin/openhush" | sed 's/^shlibs:Depends=//')"
+
+          if [ -z "${SHLIB_DEPS}" ]; then
+              echo "dpkg-shlibdeps returned no dependencies" >&2
+              exit 1
+          fi
+          echo "Computed Depends: ${SHLIB_DEPS}"
+
           # Create control file
           cat > "${PKG_DIR}/DEBIAN/control" << EOF
           Package: openhush
@@ -199,7 +241,7 @@ jobs:
           Section: utils
           Priority: optional
           Architecture: amd64
-          Depends: libasound2, libdbus-1-3, libpulse0, libx11-6, libxtst6
+          Depends: ${SHLIB_DEPS}
           Maintainer: OpenHush Team <christian.kamien@gmail.com>
           Description: Voice-to-text transcription tool
            OpenHush is a local, privacy-focused voice-to-text tool

--- a/packaging/windows/openhush.wxs
+++ b/packaging/windows/openhush.wxs
@@ -8,7 +8,7 @@
      xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
   <Package Name="OpenHush"
            Manufacturer="OpenHush Team"
-           Version="0.8.0"
+           Version="$(var.Version)"
            UpgradeCode="E8F3A2B1-5C4D-4E6F-8A9B-0C1D2E3F4A5B"
            Scope="perUser">
 


### PR DESCRIPTION
Removes the two remaining pieces of hand-maintained packaging metadata that caused this release's failures.

## 1. `.deb` dependencies are now computed, not written by hand

`release.yml` hand-rolled `DEBIAN/control` while `packaging/deb/debian/control` sat unused with a correct `\${shlibs:Depends}`. The hand-written list fell behind what the binary links against, and v0.8.0 shipped a package that installed cleanly and then couldn't start.

Now uses `dpkg-shlibdeps`, which reads the ELF `NEEDED` entries and maps each to its providing package. **Deliberately without `--ignore-missing-info`** — that flag drops libraries it can't resolve instead of failing, which is precisely how an incomplete list slips through. The job now installs the runtime libraries so resolution can succeed, and errors loudly otherwise.

## 2. MSI version is no longer hardcoded

`openhush.wxs` had `Version="0.8.0"` and never read the `$(var.Version)` that **both** `release.yml` and `build-msi.ps1` already pass. Every release needed a manual edit or shipped a stale version.

Now reads the variable. A build that forgets to pass it fails with `WIX0150: Undefined preprocessor variable` rather than silently producing a wrongly-versioned installer — verified locally both ways.

## Verification, and one thing worth knowing

I ran the packaging script's own logic inside an `ubuntu:22.04` container to reproduce exactly what CI computes, built a package with the result, and installed it in clean containers:

| Image | install | missing libs | `--version` | `config --show` |
|---|---|---|---|---|
| `ubuntu:22.04` | rc=0 | none | `openhush 0.8.0` | rc=0 |
| `debian:13` | rc=0 | none | `openhush 0.8.0` | rc=0 |

**Computing on the oldest supported distro matters.** My first attempt computed the list on Debian 13 and it failed on Ubuntu 22.04:

```
openhush : Depends: libxtst6 (>= 2:1.2.5) but it is not going to be installed
```

Ubuntu 22.04 ships 2:1.2.3. Computed on ubuntu-22.04 — which is what CI does — `libxtst6` carries no version constraint and the package installs on both. Worth preserving if the packaging runner is ever moved to a newer image.

The computed list also drops `libdbus-1-3`, which the binary never linked — D-Bus is reached through `zbus`, which is pure Rust.

No Rust changed.