### PR TITLE
fix(packaging): Correct macOS minimum version to 13.0

### DIFF
--- a/packaging/macos/build-dmg.sh
+++ b/packaging/macos/build-dmg.sh
@@ -58,8 +58,13 @@ cat > "${APP_DIR}/Contents/Info.plist" << EOF
     <string>????</string>
     <key>CFBundleIconFile</key>
     <string>AppIcon</string>
+    <!-- The binary hard-links ScreenCaptureKit (LC_LOAD_DYLIB, not weak), so
+         dyld refuses to start it on any system without that framework. It
+         arrived in macOS 12.3; the system audio capture built on it is
+         documented as requiring 13+. Claiming 11.0 here meant the app could
+         be installed on systems where it cannot launch at all. -->
     <key>LSMinimumSystemVersion</key>
-    <string>11.0</string>
+    <string>13.0</string>
     <key>LSUIElement</key>
     <true/>
     <key>NSHighResolutionCapable</key>


### PR DESCRIPTION
The v0.8.0 `.dmg` claims support for macOS 11.0 but cannot launch below 12.3.

## Evidence

Mounted the shipped `.dmg` and ran the binary:

```
dyld[483]: Library not loaded:
  /System/Library/Frameworks/ScreenCaptureKit.framework/Versions/A/ScreenCaptureKit
```

Confirmed against the shipped Mach-O that this is a **hard** link, not a weak one:

```
cmd LC_LOAD_DYLIB
name /System/Library/Frameworks/ScreenCaptureKit.framework/Versions/A/ScreenCaptureKit
```

`LC_LOAD_DYLIB` rather than `LC_LOAD_WEAK_DYLIB` means dyld refuses to start the process when the framework is absent — the app installs, then dies on launch. ScreenCaptureKit arrived in **macOS 12.3**.

`ScreenCaptureKit` is the only linked framework newer than macOS 11; the other 20 all predate it, so it alone sets the floor.

## Why 13.0 and not 12.3

`wiki/Platform-Support.md` already documents the system audio capture built on this as requiring **macOS 13+**. 12.3 is the technical floor for the framework to load; 13.0 is what the project documents as supported. Setting 13.0 makes the bundle agree with both the binary and the docs.

## The alternative

Keeping macOS 11 support would mean weak-linking (`-weak_framework ScreenCaptureKit`) and guarding every use at runtime. That is a code change rather than a packaging one, and worth doing only if macOS 11–12.2 support is actually wanted — happy to take it on if so.

## How this was found

Testing the `.dmg` in the macOS VM. It boots into Recovery, which has a Terminal, so the `.dmg` was served from the host over slirp (`10.0.2.2`), downloaded, mounted and run there — no login or SSH needed. Recovery also lacks ScreenCaptureKit, so the first failure was ambiguous; checking the installed volume (which **has** the framework) is what separated a Recovery artifact from a genuine defect.

Packaging metadata only; no Rust changed.