### PR TITLE
fix(packaging): Fix macOS Info.plist in the workflow that actually ships

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -363,14 +363,27 @@ jobs:
               <string>${VERSION}</string>
               <key>CFBundlePackageType</key>
               <string>APPL</string>
+              <!-- The binary hard-links ScreenCaptureKit (LC_LOAD_DYLIB, not
+                   weak), so dyld refuses to start it where that framework is
+                   absent. It arrived in macOS 12.3, and the system audio
+                   capture built on it is documented as needing 13+. Claiming
+                   11.0 let the app install where it cannot launch. Keep in
+                   sync with packaging/macos/build-dmg.sh. -->
               <key>LSMinimumSystemVersion</key>
-              <string>11.0</string>
+              <string>13.0</string>
               <key>LSUIElement</key>
               <true/>
               <key>NSHighResolutionCapable</key>
               <true/>
               <key>NSMicrophoneUsageDescription</key>
               <string>OpenHush needs microphone access for voice-to-text transcription.</string>
+              <!-- src/context.rs shells out to osascript to read the frontmost
+                   application. That sends Apple Events, and macOS terminates a
+                   bundled app that does so without this key. It was present in
+                   packaging/macos/build-dmg.sh but missing here, and this is
+                   the plist the release actually ships. -->
+              <key>NSAppleEventsUsageDescription</key>
+              <string>OpenHush needs to query the frontmost application to adapt transcription to its context.</string>
           </dict>
           </plist>
           EOF


### PR DESCRIPTION
**#240 did not work.** I re-tagged, downloaded the rebuilt `.dmg`, and it still declared `LSMinimumSystemVersion 11.0`.

Cause: `release.yml` hand-rolls its own `Info.plist` inline and never calls `packaging/macos/build-dmg.sh`. #240 fixed the script nobody runs. This is the same drift that caused the `.deb` dependency bug — a packaging file in `packaging/` shadowed by an inline copy in the workflow — now found in a second place.

Caught only because I read the shipped bundle instead of assuming the fix had landed.

## Two changes

**`LSMinimumSystemVersion` → 13.0**, in the plist the release actually writes.

**Adds `NSAppleEventsUsageDescription`** — present in `build-dmg.sh`, absent from the inline copy, so every shipped bundle has lacked it. `src/context.rs` shells out to `osascript` to read the frontmost application; that sends Apple Events, and macOS **terminates** a bundled app that does so without this key. Context detection would kill the app rather than degrade gracefully.

## Remaining differences, deliberately left

| Key | Why not added |
|---|---|
| `CFBundleIconFile` | no `AppIcon.icns` exists in the repo |
| `CFBundleSignature` | legacy, `'????'` is inert |

Consolidating `release.yml` onto `build-dmg.sh` is the real fix, but the script emits `OpenHush-${VERSION}-macos-universal.dmg` while the release and the Homebrew cask expect `openhush-v${VERSION}-macos-universal.dmg`. Renaming artifacts during a release is how the cask 404 happened, so that is follow-up work rather than part of this.

## Verification

Extracted the generated plist from the workflow and parsed it with `plistlib`: 11 keys, `LSMinimumSystemVersion = 13.0`, `NSAppleEventsUsageDescription` present.

No Rust changed.