### PR TITLE
fix(packaging): Update checksums for the final v0.8.0 artifacts

### DIFF
--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -27,7 +27,7 @@ optdepends=(
 provides=('openhush')
 conflicts=('openhush-git')
 source=("$pkgname-$pkgver.tar.gz::https://github.com/claymore666/openhush/archive/v$pkgver.tar.gz")
-sha256sums=('01c06b57c269593efda2cba6240c4256c225b82b9cf580eb39508478f7089f13')
+sha256sums=('bdfc8d3a7ba74aa944674a25800f4dc6158a1fec019d1186d40d2bf1494a8b81')
 
 prepare() {
     cd "$pkgname-$pkgver"

--- a/packaging/homebrew/openhush.cask.rb
+++ b/packaging/homebrew/openhush.cask.rb
@@ -3,7 +3,7 @@
 
 cask "openhush" do
   version "0.8.0"
-  sha256 "471096be71bf36913a79026e5a5befd357127417f5e109b981e54511f6906308"
+  sha256 "4966ddea71d58c843ae3a546c04d8e62ab607482ede1a529b2d562432275fc20"
 
   # Filename must match what release.yml actually uploads:
   # openhush-v<version>-macos-universal.dmg

--- a/packaging/homebrew/openhush.rb
+++ b/packaging/homebrew/openhush.rb
@@ -2,7 +2,7 @@ class Openhush < Formula
   desc "Open-source voice-to-text that acts as a seamless whisper keyboard"
   homepage "https://github.com/claymore666/openhush"
   url "https://github.com/claymore666/openhush/archive/refs/tags/v0.8.0.tar.gz"
-  sha256 "01c06b57c269593efda2cba6240c4256c225b82b9cf580eb39508478f7089f13"
+  sha256 "bdfc8d3a7ba74aa944674a25800f4dc6158a1fec019d1186d40d2bf1494a8b81"
   license "MIT"
   head "https://github.com/claymore666/openhush.git", branch: "main"
 


### PR DESCRIPTION
Re-tagging for the macOS `Info.plist` fix (#241) changed both the source archive and the `.dmg`, so the digests need updating one last time.

| File | Digest | Source |
|---|---|---|
| `homebrew/openhush.rb` | `bdfc8d3a…` | source archive |
| `aur/PKGBUILD` | `bdfc8d3a…` | source archive |
| `homebrew/openhush.cask.rb` | `4966ddea…` | published .dmg |

Source archive digest verified identical across both URL forms.

## Artifacts verified against the published release

**macOS** — read from the shipped bundle, not assumed:

```
LSMinimumSystemVersion       = 13.0
NSAppleEventsUsageDescription = present
NSMicrophoneUsageDescription  = present
CFBundleShortVersionString   = 0.8.0
binary: Mach-O universal (x86_64 + arm64)
```

**Linux** — `verify-linux-package` passed in CI, and re-checked locally against the published `.deb`: installs and runs on `ubuntu:22.04` and `debian:13`, no missing libraries, `openhush 0.8.0`.

Packaging metadata only; no Rust changed.