### PR TITLE
refactor(packaging): Consolidate the .deb and .dmg definitions into packaging/

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,7 +174,7 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y debhelper fakeroot dpkg-dev
+          sudo apt-get install -y fakeroot dpkg-dev
           # dpkg-shlibdeps resolves each NEEDED library to the package that
           # ships it, which requires those packages to be installed here.
           # Without them it cannot see the dependency at all.
@@ -186,86 +186,13 @@ jobs:
             libxtst6 \
             libssl3
 
+      # The package definition lives in packaging/, not here. Keeping it inline
+      # meant it could only ever be exercised by pushing a tag; that is how
+      # v0.8.0 shipped a .deb whose Depends had drifted from what the binary
+      # links against. Run the same script locally to reproduce this artifact.
       - name: Build .deb package
         run: |
-          VERSION="${{ github.ref_name }}"
-          VERSION="${VERSION#v}"  # Remove 'v' prefix
-
-          # Create package structure
-          PKG_DIR="openhush_${VERSION}_amd64"
-          mkdir -p "${PKG_DIR}/DEBIAN"
-          mkdir -p "${PKG_DIR}/usr/bin"
-          mkdir -p "${PKG_DIR}/usr/share/applications"
-          mkdir -p "${PKG_DIR}/usr/share/doc/openhush"
-
-          # Copy binary
-          cp artifact/openhush "${PKG_DIR}/usr/bin/"
-          chmod 755 "${PKG_DIR}/usr/bin/openhush"
-
-          # Derive the runtime dependencies from the binary itself.
-          #
-          # This list used to be written by hand and drifted out of sync with
-          # what the binary actually links against: v0.8.0 shipped a package
-          # that installed cleanly and then could not start, because libpulse,
-          # libX11 and libXtst were missing from it. dpkg-shlibdeps reads the
-          # ELF NEEDED entries and maps each one to the package that provides
-          # it, so the list cannot drift again.
-          #
-          # Deliberately no --ignore-missing-info: that flag drops libraries
-          # it cannot resolve instead of failing, which is exactly how an
-          # incomplete list would slip through unnoticed.
-          mkdir -p shlibdeps/debian
-          cat > shlibdeps/debian/control << 'CTRL'
-          Source: openhush
-
-          Package: openhush
-          Architecture: amd64
-          Depends: ${shlibs:Depends}
-          Description: placeholder used only to compute dependencies
-           dpkg-shlibdeps requires a debian/control to run against.
-          CTRL
-
-          SHLIB_DEPS="$(cd shlibdeps && dpkg-shlibdeps -O \
-              "../${PKG_DIR}/usr/bin/openhush" | sed 's/^shlibs:Depends=//')"
-
-          if [ -z "${SHLIB_DEPS}" ]; then
-              echo "dpkg-shlibdeps returned no dependencies" >&2
-              exit 1
-          fi
-          echo "Computed Depends: ${SHLIB_DEPS}"
-
-          # Create control file
-          cat > "${PKG_DIR}/DEBIAN/control" << EOF
-          Package: openhush
-          Version: ${VERSION}
-          Section: utils
-          Priority: optional
-          Architecture: amd64
-          Depends: ${SHLIB_DEPS}
-          Maintainer: OpenHush Team <christian.kamien@gmail.com>
-          Description: Voice-to-text transcription tool
-           OpenHush is a local, privacy-focused voice-to-text tool
-           that runs entirely on your machine using Whisper AI models.
-          EOF
-
-          # Create desktop entry
-          cat > "${PKG_DIR}/usr/share/applications/openhush.desktop" << EOF
-          [Desktop Entry]
-          Name=OpenHush
-          Comment=Voice-to-text transcription
-          Exec=openhush
-          Icon=openhush
-          Terminal=false
-          Type=Application
-          Categories=Utility;Audio;
-          EOF
-
-          # Copy license
-          cp LICENSE "${PKG_DIR}/usr/share/doc/openhush/copyright"
-
-          # Build package
-          fakeroot dpkg-deb --build "${PKG_DIR}"
-          mv "${PKG_DIR}.deb" "openhush-${{ github.ref_name }}-amd64.deb"
+          packaging/deb/build-deb.sh "${{ github.ref_name }}" artifact/openhush .
 
       - name: Upload .deb artifact
         uses: actions/upload-artifact@v7
@@ -330,69 +257,13 @@ jobs:
           lipo -create -output openhush x86_64/openhush aarch64/openhush
           chmod +x openhush
 
-      - name: Install create-dmg
-        run: brew list create-dmg &>/dev/null || brew install create-dmg
-
+      # Same reasoning as the .deb: one definition, in packaging/, runnable
+      # by hand. The inline copy this replaces had drifted from
+      # packaging/macos/build-dmg.sh, and it was the inline one that shipped —
+      # so a fix landed in the script while users kept getting the stale plist.
       - name: Build DMG
         run: |
-          VERSION="${{ github.ref_name }}"
-          VERSION="${VERSION#v}"
-
-          # Create app bundle
-          APP_DIR="OpenHush.app"
-          mkdir -p "${APP_DIR}/Contents/MacOS"
-          mkdir -p "${APP_DIR}/Contents/Resources"
-
-          cp openhush "${APP_DIR}/Contents/MacOS/"
-
-          # Create Info.plist
-          cat > "${APP_DIR}/Contents/Info.plist" << EOF
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-          <plist version="1.0">
-          <dict>
-              <key>CFBundleExecutable</key>
-              <string>openhush</string>
-              <key>CFBundleIdentifier</key>
-              <string>org.openhush.OpenHush</string>
-              <key>CFBundleName</key>
-              <string>OpenHush</string>
-              <key>CFBundleVersion</key>
-              <string>${VERSION}</string>
-              <key>CFBundleShortVersionString</key>
-              <string>${VERSION}</string>
-              <key>CFBundlePackageType</key>
-              <string>APPL</string>
-              <!-- The binary hard-links ScreenCaptureKit (LC_LOAD_DYLIB, not
-                   weak), so dyld refuses to start it where that framework is
-                   absent. It arrived in macOS 12.3, and the system audio
-                   capture built on it is documented as needing 13+. Claiming
-                   11.0 let the app install where it cannot launch. Keep in
-                   sync with packaging/macos/build-dmg.sh. -->
-              <key>LSMinimumSystemVersion</key>
-              <string>13.0</string>
-              <key>LSUIElement</key>
-              <true/>
-              <key>NSHighResolutionCapable</key>
-              <true/>
-              <key>NSMicrophoneUsageDescription</key>
-              <string>OpenHush needs microphone access for voice-to-text transcription.</string>
-              <!-- src/context.rs shells out to osascript to read the frontmost
-                   application. That sends Apple Events, and macOS terminates a
-                   bundled app that does so without this key. It was present in
-                   packaging/macos/build-dmg.sh but missing here, and this is
-                   the plist the release actually ships. -->
-              <key>NSAppleEventsUsageDescription</key>
-              <string>OpenHush needs to query the frontmost application to adapt transcription to its context.</string>
-          </dict>
-          </plist>
-          EOF
-
-          # Create DMG (simple method for unsigned builds)
-          hdiutil create -volname "OpenHush ${VERSION}" \
-              -srcfolder "${APP_DIR}" \
-              -ov -format UDZO \
-              "openhush-${{ github.ref_name }}-macos-universal.dmg"
+          packaging/macos/build-dmg.sh "${{ github.ref_name }}" openhush .
 
       - name: Upload .dmg artifact
         uses: actions/upload-artifact@v7

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -13,6 +13,28 @@ This directory contains packaging files for all supported platforms.
 | MSI | Windows | `windows/` | Ready |
 | DMG | macOS | `macos/` | Ready |
 
+## What the release actually builds
+
+`release.yml` runs only on a tag push, so anything defined inline in it can
+drift for a whole release cycle without anyone noticing. It used to hand-roll
+its own `.deb` control file and its own `Info.plist`, and both drifted: PR #240
+corrected `LSMinimumSystemVersion` in `macos/build-dmg.sh` while the workflow
+kept shipping the stale value from its own copy.
+
+Each released artifact now has exactly one definition, and it lives here:
+
+| Artifact | Built by | Notes |
+|----------|----------|-------|
+| `openhush-v<ver>-amd64.deb` | `deb/build-deb.sh` | Repacks the CI binary. `Depends` derived from the ELF via `dpkg-shlibdeps`. |
+| `openhush-v<ver>-macos-universal.dmg` | `macos/build-dmg.sh` | Name is fixed by `homebrew/openhush.cask.rb`. |
+| `openhush-v<ver>-x64.msi` | `windows/openhush.wxs` | Version passed in with `-d Version=`. |
+
+Run any of them by hand and you get the same artifact CI does. If you change
+how a package is built, change it there — not in the workflow.
+
+`deb/debian/` is a separate, from-source path for distribution packagers using
+`dpkg-buildpackage`. It is not what the release ships.
+
 ---
 
 ## Linux
@@ -49,15 +71,34 @@ makepkg -si
 
 **Location:** `deb/`
 
+Two paths, for two different audiences.
+
+**`build-deb.sh` — what the release ships.** Repacks an already-built binary:
+
 ```bash
-# Install build dependencies
+sudo apt install fakeroot dpkg-dev
+cargo build --release
+
+# <version> <binary> [outdir]
+packaging/deb/build-deb.sh 0.8.0 target/release/openhush .
+packaging/verify-deb.sh openhush-v0.8.0-amd64.deb
+```
+
+`Depends` is computed with `dpkg-shlibdeps` rather than written by hand, so it
+cannot fall behind what the binary links against. That means the libraries it
+links must be installed when you build, and that the resulting versions match
+the distro you build on — CI uses `ubuntu-22.04`, the oldest supported target,
+because a dependency computed on a newer distro is unsatisfiable on an older
+one.
+
+**`debian/` — from source, for distribution packagers:**
+
+```bash
 sudo apt install debhelper cargo rustc libasound2-dev libdbus-1-dev libgtk-3-dev
 
-# Build package (from project root)
+# From the project root
 cp -r packaging/deb/debian .
 dpkg-buildpackage -us -uc -b
-
-# Install
 sudo dpkg -i ../openhush_0.8.0-1_amd64.deb
 ```
 
@@ -86,17 +127,24 @@ brew install --formula packaging/homebrew/openhush.rb
 
 **Location:** `macos/`
 
-```bash
-# Requires: create-dmg
-brew install create-dmg
+This is the script the release runs; nothing beyond a stock macOS is needed.
 
-# Build DMG
-cd packaging/macos
-./build-dmg.sh 0.8.0 ../../target/release/openhush
+```bash
+cargo build --release --features metal
+
+# <version> <binary> [outdir]  ->  openhush-v0.8.0-macos-universal.dmg
+packaging/macos/build-dmg.sh 0.8.0 target/release/openhush .
 
 # Optional: Sign and notarize
-./sign-and-notarize.sh OpenHush.app OpenHush-0.8.0-macos-universal.dmg
+packaging/macos/sign-and-notarize.sh OpenHush.app openhush-v0.8.0-macos-universal.dmg
 ```
+
+The output name is what `homebrew/openhush.cask.rb` downloads. Changing it
+breaks the cask, so change both together.
+
+`LSMinimumSystemVersion` is 13.0 because the binary hard-links
+ScreenCaptureKit; on an older system dyld refuses to start it at all. Raise it
+only alongside an actual change in what the binary links.
 
 **Code Signing:**
 - Requires Apple Developer account ($99/year)
@@ -191,8 +239,10 @@ Before releasing a new version:
    - `packaging/homebrew/openhush.rb`
    - `packaging/homebrew/openhush.cask.rb`
    - `packaging/windows/openhush.wxs`
-   - `packaging/windows/build-msi.ps1`
-   - `packaging/macos/build-dmg.sh`
+   - `packaging/windows/build-msi.ps1` (default `-Version` only)
+
+   `packaging/deb/build-deb.sh` and `packaging/macos/build-dmg.sh` take the
+   version as an argument and need no bump.
 
 2. **Update Checksums:**
 

--- a/packaging/deb/build-deb.sh
+++ b/packaging/deb/build-deb.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+#
+# Build a .deb from an already-compiled openhush binary.
+#
+# This is the path the release uses: CI builds the binary once, then repacks
+# it here. It is deliberately separate from debian/, which is the from-source
+# path for distribution packagers using dpkg-buildpackage.
+#
+# The definition used to live inline in .github/workflows/release.yml. Keeping
+# it there meant it could only be exercised by pushing a tag, and it silently
+# drifted from reality: v0.8.0 shipped a package that installed cleanly and
+# then could not start, because its Depends were written by hand and had
+# fallen behind what the binary links against. Now the release calls this
+# script, so what CI ships is what you can run locally.
+#
+# Usage:
+#   packaging/deb/build-deb.sh <version> <binary> [outdir] [license]
+#
+# Verify the result with:
+#   packaging/verify-deb.sh <path-to-deb>
+#
+# Requires: dpkg-dev (dpkg-shlibdeps, dpkg-deb) and fakeroot. The libraries
+# the binary links against must be installed, or dpkg-shlibdeps cannot map
+# them to packages.
+
+set -euo pipefail
+
+VERSION="${1:-}"
+BINARY="${2:-}"
+OUTDIR="${3:-.}"
+LICENSE_FILE="${4:-LICENSE}"
+
+if [[ -z "${VERSION}" || -z "${BINARY}" ]]; then
+    echo "usage: $0 <version> <binary> [outdir] [license]" >&2
+    exit 2
+fi
+if [[ ! -f "${BINARY}" ]]; then
+    echo "error: binary not found at ${BINARY}" >&2
+    exit 1
+fi
+
+VERSION="${VERSION#v}"
+mkdir -p "${OUTDIR}"
+OUTDIR="$(cd "${OUTDIR}" && pwd)"
+BINARY="$(cd "$(dirname "${BINARY}")" && pwd)/$(basename "${BINARY}")"
+[[ -f "${LICENSE_FILE}" ]] && LICENSE_FILE="$(cd "$(dirname "${LICENSE_FILE}")" && pwd)/$(basename "${LICENSE_FILE}")"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "${WORK}"' EXIT
+
+PKG_DIR="${WORK}/openhush_${VERSION}_amd64"
+mkdir -p "${PKG_DIR}/DEBIAN" \
+         "${PKG_DIR}/usr/bin" \
+         "${PKG_DIR}/usr/share/applications" \
+         "${PKG_DIR}/usr/share/doc/openhush"
+
+install -m 755 "${BINARY}" "${PKG_DIR}/usr/bin/openhush"
+
+# Derive the runtime dependencies from the binary rather than maintaining a
+# list by hand. dpkg-shlibdeps reads the ELF NEEDED entries and maps each to
+# the package providing it, so the list cannot drift from what is linked.
+#
+# Deliberately no --ignore-missing-info: that flag drops libraries it cannot
+# resolve instead of failing, which is precisely how an incomplete list slips
+# through unnoticed.
+mkdir -p "${WORK}/shlibdeps/debian"
+cat > "${WORK}/shlibdeps/debian/control" <<'CTRL'
+Source: openhush
+
+Package: openhush
+Architecture: amd64
+Depends: ${shlibs:Depends}
+Description: placeholder used only to compute dependencies
+ dpkg-shlibdeps requires a debian/control to run against.
+CTRL
+
+SHLIB_DEPS="$(cd "${WORK}/shlibdeps" && dpkg-shlibdeps -O \
+    "${PKG_DIR}/usr/bin/openhush" | sed 's/^shlibs:Depends=//')"
+
+if [[ -z "${SHLIB_DEPS}" ]]; then
+    echo "error: dpkg-shlibdeps returned no dependencies" >&2
+    exit 1
+fi
+echo "Computed Depends: ${SHLIB_DEPS}"
+
+cat > "${PKG_DIR}/DEBIAN/control" <<EOF
+Package: openhush
+Version: ${VERSION}
+Section: utils
+Priority: optional
+Architecture: amd64
+Depends: ${SHLIB_DEPS}
+Maintainer: OpenHush Team <christian.kamien@gmail.com>
+Description: Voice-to-text transcription tool
+ OpenHush is a local, privacy-focused voice-to-text tool
+ that runs entirely on your machine using Whisper AI models.
+EOF
+
+cat > "${PKG_DIR}/usr/share/applications/openhush.desktop" <<'EOF'
+[Desktop Entry]
+Name=OpenHush
+Comment=Voice-to-text transcription
+Exec=openhush
+Icon=openhush
+Terminal=false
+Type=Application
+Categories=Utility;Audio;
+EOF
+
+if [[ -f "${LICENSE_FILE}" ]]; then
+    install -m 644 "${LICENSE_FILE}" "${PKG_DIR}/usr/share/doc/openhush/copyright"
+fi
+
+# The metadata and data files above are created through redirection, so their
+# modes come from the caller's umask. A restrictive umask would otherwise
+# produce a package whose files are unreadable by anyone but root.
+find "${PKG_DIR}/DEBIAN" "${PKG_DIR}/usr/share" -type f -exec chmod 644 {} +
+find "${PKG_DIR}" -type d -exec chmod 755 {} +
+
+fakeroot dpkg-deb --build "${PKG_DIR}" >/dev/null
+mv "${PKG_DIR}.deb" "${OUTDIR}/openhush-v${VERSION}-amd64.deb"
+
+echo "Built ${OUTDIR}/openhush-v${VERSION}-amd64.deb"

--- a/packaging/macos/build-dmg.sh
+++ b/packaging/macos/build-dmg.sh
@@ -1,41 +1,58 @@
-#!/bin/bash
-# Build macOS DMG installer
-# Requires: create-dmg (brew install create-dmg)
+#!/usr/bin/env bash
+#
+# Build the macOS .app bundle and .dmg from an already-compiled binary.
+#
+# This is the definition the release uses. It used to be duplicated inline in
+# .github/workflows/release.yml, and the two copies drifted: PR #240 corrected
+# LSMinimumSystemVersion here while the release kept shipping the stale value
+# from its own copy, and NSAppleEventsUsageDescription existed only here even
+# though the workflow's plist is the one that reaches users. There is now one
+# copy, and the release calls it.
+#
+# Usage:
+#   packaging/macos/build-dmg.sh <version> <binary> [outdir]
+#
+# Produces <outdir>/openhush-v<version>-macos-universal.dmg. That exact name is
+# what packaging/homebrew/openhush.cask.rb downloads; do not change it without
+# changing the cask.
+#
+# Requires: macOS (hdiutil, plutil).
 
-set -e
+set -euo pipefail
 
-VERSION="${1:-0.8.0}"
-BINARY_PATH="${2:-../../target/release/openhush}"
-OUTPUT_DIR="${3:-.}"
-APP_NAME="OpenHush"
-DMG_NAME="OpenHush-${VERSION}-macos-universal"
+VERSION="${1:-}"
+BINARY="${2:-}"
+OUTDIR="${3:-.}"
 
-echo "Building OpenHush DMG v${VERSION}"
-
-# Check prerequisites
-if ! command -v create-dmg &> /dev/null; then
-    echo "Error: create-dmg not found"
-    echo "Install with: brew install create-dmg"
+if [[ -z "${VERSION}" || -z "${BINARY}" ]]; then
+    echo "usage: $0 <version> <binary> [outdir]" >&2
+    exit 2
+fi
+if [[ ! -f "${BINARY}" ]]; then
+    echo "error: binary not found at ${BINARY}" >&2
+    echo "build it with: cargo build --release --features metal" >&2
     exit 1
 fi
 
-if [ ! -f "$BINARY_PATH" ]; then
-    echo "Error: Binary not found at $BINARY_PATH"
-    echo "Build with: cargo build --release --features metal"
-    exit 1
-fi
+VERSION="${VERSION#v}"
+mkdir -p "${OUTDIR}"
+OUTDIR="$(cd "${OUTDIR}" && pwd)"
+BINARY="$(cd "$(dirname "${BINARY}")" && pwd)/$(basename "${BINARY}")"
 
-# Create temporary app bundle directory
-APP_DIR="$(mktemp -d)/${APP_NAME}.app"
-mkdir -p "${APP_DIR}/Contents/MacOS"
-mkdir -p "${APP_DIR}/Contents/Resources"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DMG="${OUTDIR}/openhush-v${VERSION}-macos-universal.dmg"
 
-# Copy binary
-cp "$BINARY_PATH" "${APP_DIR}/Contents/MacOS/openhush"
-chmod +x "${APP_DIR}/Contents/MacOS/openhush"
+WORK="$(mktemp -d)"
+trap 'rm -rf "${WORK}"' EXIT
 
-# Create Info.plist
-cat > "${APP_DIR}/Contents/Info.plist" << EOF
+# Everything in STAGE becomes the contents of the mounted volume.
+STAGE="${WORK}/stage"
+APP_DIR="${STAGE}/OpenHush.app"
+mkdir -p "${APP_DIR}/Contents/MacOS" "${APP_DIR}/Contents/Resources"
+
+install -m 755 "${BINARY}" "${APP_DIR}/Contents/MacOS/openhush"
+
+cat > "${APP_DIR}/Contents/Info.plist" <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -56,13 +73,11 @@ cat > "${APP_DIR}/Contents/Info.plist" << EOF
     <string>APPL</string>
     <key>CFBundleSignature</key>
     <string>????</string>
-    <key>CFBundleIconFile</key>
-    <string>AppIcon</string>
     <!-- The binary hard-links ScreenCaptureKit (LC_LOAD_DYLIB, not weak), so
-         dyld refuses to start it on any system without that framework. It
-         arrived in macOS 12.3; the system audio capture built on it is
-         documented as requiring 13+. Claiming 11.0 here meant the app could
-         be installed on systems where it cannot launch at all. -->
+         dyld refuses to start it on a system without that framework. It
+         arrived in macOS 12.3, and the system audio capture built on it is
+         documented as needing 13+. Claiming 11.0 let the app install where it
+         cannot launch at all. -->
     <key>LSMinimumSystemVersion</key>
     <string>13.0</string>
     <key>LSUIElement</key>
@@ -71,52 +86,45 @@ cat > "${APP_DIR}/Contents/Info.plist" << EOF
     <true/>
     <key>NSMicrophoneUsageDescription</key>
     <string>OpenHush needs microphone access for voice-to-text transcription.</string>
+    <!-- src/context.rs shells out to osascript to read the frontmost
+         application. That sends Apple Events, and macOS terminates a bundled
+         app that does so without this key. -->
     <key>NSAppleEventsUsageDescription</key>
-    <string>OpenHush needs accessibility access to type transcribed text.</string>
+    <string>OpenHush needs to query the frontmost application to adapt transcription to its context.</string>
+EOF
+
+# Only declare an icon when one is actually present. The previous version
+# referenced AppIcon unconditionally and passed --volicon for a file that does
+# not exist in this repo, which made every create-dmg run fail into a silent
+# fallback.
+if [[ -f "${HERE}/AppIcon.icns" ]]; then
+    cp "${HERE}/AppIcon.icns" "${APP_DIR}/Contents/Resources/"
+    cat >> "${APP_DIR}/Contents/Info.plist" <<'EOF'
+    <key>CFBundleIconFile</key>
+    <string>AppIcon</string>
+EOF
+else
+    echo "note: no AppIcon.icns in ${HERE}; building without an icon"
+fi
+
+cat >> "${APP_DIR}/Contents/Info.plist" <<'EOF'
 </dict>
 </plist>
 EOF
 
-# Copy icon if exists
-if [ -f "AppIcon.icns" ]; then
-    cp "AppIcon.icns" "${APP_DIR}/Contents/Resources/"
-fi
+# A malformed plist produces a bundle that silently refuses to launch, so
+# reject it here rather than at the user's machine.
+plutil -lint "${APP_DIR}/Contents/Info.plist"
 
-# Create DMG
-echo "Creating DMG..."
-mkdir -p "$OUTPUT_DIR"
+# Lets someone who opens the .dmg drag the app across without leaving the
+# window. Homebrew's cask ignores it and installs OpenHush.app directly.
+ln -s /Applications "${STAGE}/Applications"
 
-create-dmg \
-    --volname "OpenHush ${VERSION}" \
-    --volicon "AppIcon.icns" \
-    --window-pos 200 120 \
-    --window-size 600 400 \
-    --icon-size 100 \
-    --icon "${APP_NAME}.app" 150 185 \
-    --hide-extension "${APP_NAME}.app" \
-    --app-drop-link 450 185 \
-    --no-internet-enable \
-    "${OUTPUT_DIR}/${DMG_NAME}.dmg" \
-    "${APP_DIR}/../" \
-    2>/dev/null || {
-        # Fallback if create-dmg options fail
-        echo "Using simple DMG creation..."
-        hdiutil create -volname "OpenHush ${VERSION}" \
-            -srcfolder "${APP_DIR}/../" \
-            -ov -format UDZO \
-            "${OUTPUT_DIR}/${DMG_NAME}.dmg"
-    }
+rm -f "${DMG}"
+hdiutil create -volname "OpenHush ${VERSION}" \
+    -srcfolder "${STAGE}" \
+    -ov -format UDZO \
+    "${DMG}"
 
-# Calculate SHA256
-if [ -f "${OUTPUT_DIR}/${DMG_NAME}.dmg" ]; then
-    echo "DMG created: ${OUTPUT_DIR}/${DMG_NAME}.dmg"
-    shasum -a 256 "${OUTPUT_DIR}/${DMG_NAME}.dmg"
-else
-    echo "Error: DMG creation failed"
-    exit 1
-fi
-
-# Cleanup
-rm -rf "$(dirname "$APP_DIR")"
-
-echo "Done!"
+echo "Built ${DMG}"
+shasum -a 256 "${DMG}"


### PR DESCRIPTION
## Problem

`release.yml` hand-rolled its own `.deb` control file and its own `Info.plist`, duplicating `packaging/deb/` and `packaging/macos/build-dmg.sh`. The workflow runs **only on a tag push**, so the copies could drift for an entire release cycle with nothing to catch it — and they did. Three of the ten bugs found during the v0.8.0 release trace back to this duplication:

- **PR #240 fixed the wrong file.** It corrected `LSMinimumSystemVersion` in `build-dmg.sh` while the release kept shipping `11.0` from its own copy. Only reading the published bundle caught it — after the tag.
- **`NSAppleEventsUsageDescription` existed only in the copy users never get.** macOS terminates a bundled app that sends Apple Events without it, and `src/context.rs` shells out to `osascript`.
- **The `.deb` `Depends` were written by hand** and fell behind what the binary links against, so v0.8.0 installed cleanly and then could not start.

## Change

Each released artifact now has exactly one definition, in `packaging/`, runnable by hand:

| Artifact | Built by |
|---|---|
| `openhush-v<ver>-amd64.deb` | `packaging/deb/build-deb.sh` |
| `openhush-v<ver>-macos-universal.dmg` | `packaging/macos/build-dmg.sh` |
| `openhush-v<ver>-x64.msi` | `packaging/windows/openhush.wxs` (already consolidated) |

The workflow calls them instead of re-implementing them. What CI ships is now reproducible locally, which is what makes drift visible *before* a tag rather than after one. `packaging/README.md` documents which file feeds which artifact.

`packaging/deb/debian/` is untouched — it remains the separate from-source path for distribution packagers.

## Behaviour is preserved

- The `.deb` is identical to the one v0.8.0 shipped in **file list and every control field**.
- The `Info.plist` keeps **every key the released bundle had, at the same values** (adds only `CFBundleDisplayName` and `CFBundleSignature`).

## Bugs found while consolidating

- `build-dmg.sh` passed `--volicon AppIcon.icns` — **a file absent from this repo** — so `create-dmg` failed on *every* run into a fallback that swallowed its stderr. The icon is now conditional, and the DMG is built with `hdiutil` directly: one code path, no silent fallback, and the same tool the release has actually been using all along.
- `build-dmg.sh` emitted `OpenHush-<ver>-...`, **not the name the Homebrew cask downloads**. It now emits the released name.
- Package file modes came from the caller's umask; a restrictive one produced a `.deb` whose files only root could read. Now set explicitly.
- `Info.plist` is checked with `plutil -lint`, since a malformed one yields a bundle that fails to launch with no useful error.
- Added an `/Applications` symlink to the `.dmg` so it installs by dragging without leaving the window.

## Verification

`build-deb.sh` was run in an `ubuntu:22.04` container **exactly as the workflow invokes it**, against the real v0.8.0 release binary:

- Computed `Depends`: `libasound2 (>= 1.0.29), libc6 (>= 2.35), libgcc-s1 (>= 4.2), libpulse0 (>= 0.99.4), libssl3 (>= 3.0.0~~alpha1), libstdc++6 (>= 11), libx11-6, libxtst6`
- `packaging/verify-deb.sh` — **PASS on `ubuntu:22.04` and `debian:13`**
- File list and control fields identical to the shipped `.deb`, **even under `umask 077`**
- `shellcheck` clean; `cargo fmt --check` and `cargo clippy -- -D warnings` clean (no Rust changed)

**The macOS half can only be exercised by CI** — there is no local macOS build environment. Its bundle layout, output name and generated plist were verified against the plist the release currently emits, with the macOS-only tools stubbed. The `.dmg` name is unchanged, so the Homebrew cask keeps working.

No re-tag needed; this affects the next release.