### PR TITLE
ci(deps): Stop dependabot proposing ort bumps it cannot build

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,14 @@ updates:
       # Ignore major version updates for stability (review manually)
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+      # ort is pinned exactly in Cargo.toml and cannot be bumped on its own.
+      # It is a pre-release that breaks its API between release candidates,
+      # and silero-vad-rust (6.2.1, its latest) requires "^2.0.0-rc.10" while
+      # only compiling against rc.10 itself. Cargo treats that caret range as
+      # allowing rc.13, so a bump resolves cleanly and then fails to build --
+      # entirely inside silero-vad-rust, not in our code. That is what PR #243
+      # was. Unignore this once silero-vad-rust supports a newer rc.
+      - dependency-name: "ort"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Why

PR #243 (`ort` 2.0.0-rc.10 → rc.13) has been red since 2026-08-17, and dependabot will recreate it every Monday.

The bump **cannot work**, and not because of anything in this repo:

- `ort` is a pre-release that breaks its API between release candidates — which is why `Cargo.toml` already pins it exactly, with that reason recorded in a comment.
- `silero-vad-rust` **6.2.1 — its latest release** — declares `ort = "^2.0.0-rc.10"` but only compiles against rc.10 itself.
- Cargo reads that caret range as permitting rc.13, so the bump **resolves cleanly and then fails to build**.

I reproduced it locally. Every error came from inside `silero-vad-rust 6.2.1` (`CPUExecutionProvider` gone from `ort::execution_providers`, `Tensor::from_array` trait bounds changed, `SessionBuilder` error type changed). **Zero errors in `src/`.**

## Change

Add `ort` to the cargo `ignore:` list in `.github/dependabot.yml`, with the reasoning and the condition for removing it again — once `silero-vad-rust` supports a newer rc.

I'd suggest closing #243 as not-actionable rather than leaving it open and red.